### PR TITLE
Update Nimbus client configuration to use mev-boost

### DIFF
--- a/prepare-for-the-merge.md
+++ b/prepare-for-the-merge.md
@@ -276,7 +276,8 @@ through August 2022. When in doubt consult each client's `--help`.
 
 - Prysm consensus: `--http-mev-relay=http://127.0.0.1:18550`
 - Prysm validator: `--enable-builder`
-- Nimbus combined: `--payload-builder=true --payload-builder-url=http://127.0.0.1:18550`
+- Nimbus consensus: `--payload-builder=true --payload-builder-url=http://127.0.0.1:18550`
+- Nimbus validator: `--payload-builder=true`
 - Lodestar consensus: `--builder --builder.urls http://127.0.0.1:18550`
 - Lodestar validator: `--builder`
 - Teku combined: `--validators-builder-registration-default-enabled=true --builder-endpoint=http://127.0.0.1:18550`


### PR DESCRIPTION
From version 23.1.0, Nimbus upgraded to run as 2 independent processes, 1 binary for the Beacon Chain and 1 binary for the validator (so 2 different services). According to https://nimbus.guide/external-block-builder.html "External block building is must be enabled on both beacon node and validator client".